### PR TITLE
Add forecast and fix pressure encoding

### DIFF
--- a/Oregon_TM.cpp
+++ b/Oregon_TM.cpp
@@ -723,9 +723,6 @@ void Oregon_TM::setPressure(float mm_hg_pressure)
     SendBuffer[7] &= 0xF0;
     SendBuffer[7] += pressure & 0x0F;
     SendBuffer[8] = (pressure & 0x0F0) + ((pressure & 0xF00) >> 8);
-    //прогноз - переменно
-    SendBuffer[9] &= 0x0F;
-    SendBuffer[9] += 0x60;
   }
 
   if (sens_type == BTHGN129)
@@ -734,10 +731,28 @@ void Oregon_TM::setPressure(float mm_hg_pressure)
     SendBuffer[7] &= 0xF0;
     SendBuffer[7] += pressure & 0x0F;
     SendBuffer[8] = (pressure & 0x0F0) + ((pressure & 0xF00) >> 8);
-    SendBuffer[9] &= 0x0F;
-    SendBuffer[9] += 0x60;
   }
 
+  if (mm_hg_pressure < 1000)
+  {
+    // rainy
+    SendBuffer[9] = 0x30;
+  }
+  else if (mm_hg_pressure < 1010)
+  {
+    // cloudy
+    SendBuffer[9] = 0x20;
+  }
+  else if (mm_hg_pressure < 1025)
+  {
+    // partly cloudy
+    SendBuffer[9] = 0x60;
+  }
+  else
+  {
+    // Sunny
+    SendBuffer[9] = 0xC0;
+  }
 }
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void Oregon_TM::setTemperature(float temp)

--- a/Oregon_TM.cpp
+++ b/Oregon_TM.cpp
@@ -50,7 +50,10 @@ Oregon_TM::Oregon_TM(byte tr_pin, int buf_size)
   TX_PIN = tr_pin;
   pinMode(TX_PIN, OUTPUT);
   digitalWrite(TX_PIN, LOW);
-
+}
+Oregon_TM::~Oregon_TM()
+{
+  delete SendBuffer;
 }
 
 Oregon_TM::Oregon_TM(byte tr_pin)

--- a/Oregon_TM.cpp
+++ b/Oregon_TM.cpp
@@ -695,20 +695,16 @@ void Oregon_TM::setId(byte ID)
 void Oregon_TM::setBatteryFlag(bool level)
 {
   SendBuffer[3] &= 0xFB;
-  if (level)
-    SendBuffer[3] |= 0x04;
+  if (level) SendBuffer[3] |= 0x04;
 }
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 void Oregon_TM::setStartCount(byte startcount)
 {
   SendBuffer[3] &= 0xF4;
-  if (startcount == 8)
-    SendBuffer[3] |= 0x08;
-  if (startcount == 2)
-    SendBuffer[3] |= 0x02;
-  if (startcount == 1)
-    SendBuffer[3] |= 0x01;
+  if (startcount == 8) SendBuffer[3] |= 0x08;
+  if (startcount == 2) SendBuffer[3] |= 0x02;
+  if (startcount == 1) SendBuffer[3] |= 0x01;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Oregon_TM.cpp
+++ b/Oregon_TM.cpp
@@ -695,31 +695,35 @@ void Oregon_TM::setId(byte ID)
 void Oregon_TM::setBatteryFlag(bool level)
 {
   SendBuffer[3] &= 0xFB;
-  if (level) SendBuffer[3] |= 0x04;
+  if (level)
+    SendBuffer[3] |= 0x04;
 }
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 void Oregon_TM::setStartCount(byte startcount)
 {
   SendBuffer[3] &= 0xF4;
-  if (startcount == 8) SendBuffer[3] |= 0x08;
-  if (startcount == 2) SendBuffer[3] |= 0x02;
-  if (startcount == 1) SendBuffer[3] |= 0x01;
+  if (startcount == 8)
+    SendBuffer[3] |= 0x08;
+  if (startcount == 2)
+    SendBuffer[3] |= 0x02;
+  if (startcount == 1)
+    SendBuffer[3] |= 0x01;
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 void Oregon_TM::setPressure(float mm_hg_pressure)
 {
+  byte pressure;
+  
   //Ограничения датчика по даташиту
-  word pressure =  (word)(mm_hg_pressure / 0.75);
-  if (mm_hg_pressure < 450) pressure = 600;
-  if (mm_hg_pressure > 790) pressure = 1054;
+  // if (mm_hg_pressure < 450) pressure = 600;
+  // if (mm_hg_pressure > 790) pressure = 1054;
 
   if (sens_type == BTHR968)
   {
-    pressure -=  600;
+    pressure = (byte)(mm_hg_pressure-856);
     SendBuffer[7] &= 0xF0;
     SendBuffer[7] += pressure & 0x0F;
     SendBuffer[8] = (pressure & 0x0F0) + ((pressure & 0xF00) >> 8);
@@ -727,12 +731,13 @@ void Oregon_TM::setPressure(float mm_hg_pressure)
 
   if (sens_type == BTHGN129)
   {
-    pressure -=  545;
+    pressure = (byte)(mm_hg_pressure-795);
     SendBuffer[7] &= 0xF0;
     SendBuffer[7] += pressure & 0x0F;
     SendBuffer[8] = (pressure & 0x0F0) + ((pressure & 0xF00) >> 8);
   }
 
+  // prediction on nibble 18
   if (mm_hg_pressure < 1000)
   {
     // rainy

--- a/Oregon_TM.h
+++ b/Oregon_TM.h
@@ -73,6 +73,7 @@ class Oregon_TM
     Oregon_TM(byte, int);
     Oregon_TM(byte);
     Oregon_TM();
+    ~Oregon_TM();
     void setType(word);
     void setChannel( byte);
     void setId(byte);


### PR DESCRIPTION
Encoding of pressure and forecast values been checked with RFlink decoder. Hence it may not be exact match of Oregon product, but simulated sensors now perfectly works.
Pls add `hacktoberfest-accepted` tag on the MR if you accept it, thanks.